### PR TITLE
use tabular config instead of passing parameters to tabular_learner

### DIFF
--- a/nbs/course2020/tabular/02_Regression_and_Permutation_Importance.ipynb
+++ b/nbs/course2020/tabular/02_Regression_and_Permutation_Importance.ipynb
@@ -1154,9 +1154,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learn = tabular_learner(dls, layers=[1000,500], ps=[0.001, 0.01],\n",
-    "                       embed_p=0.04, y_range=y_range, metrics=exp_rmspe,\n",
-    "                       loss_func=MSELossFlat())"
+    "tc = tabular_config(ps=[0.001, 0.01], embed_p=0.04, y_range=y_range)\n",
+    "learn = tabular_learner(dls, layers=[1000,500],\n",
+    "                        metrics=exp_rmspe,\n",
+    "                        config=tc,\n",
+    "                        loss_func=MSELossFlat())"
    ]
   },
   {


### PR DESCRIPTION
It seems this parameters are no longer on [tabular_learner](https://github.com/fastai/fastai/blob/00e4569645120444761394ab73595ea80454189b/fastai/tabular/learner.py#L24) but it still includes `y-range` which could be in call or in config, so I put in config.