### PR TITLE
02_MNIST inconsistency fixes

### DIFF
--- a/nbs/course2020/vision/02_MNIST.ipynb
+++ b/nbs/course2020/vision/02_MNIST.ipynb
@@ -713,7 +713,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then also call `learn.summary` to take a look at all the sizes with thier **exact** output shapes"
+    "We can then also call `learn.summary` to take a look at all the sizes with their **exact** output shapes"
    ]
   },
   {


### PR DESCRIPTION
Hi Zach, 
This is the small PR I mentioned on Discord, it fixes 2 minor inconsistencies:
1) Description of the convolutional layer that you used uses 5x5 kernel and (more importantly) stride=1 resulting in 28x28 output layer of the first convolution. In the model you build below, the first layer has shape 14x14 due to stride=2. I added paragraph that provides a bit of clarification to those differences as well as link to more in-depth explanation of conv layers
2) In the first net you build, you use the `nn.Conv2d` layer from PyTorch, which has bias on by default. This results in (3x3 +1) x 8 = 80 parameters for the first layer instead of expected 72 (other layers are altered the same way). Later in the notebook you use `ConvLayer` from FastAI, which has bias=None, resulting in expected number of params. I added `bias=False` to the initial `conv` definition for consistency.

There were also 1 or 2 typos in the notebook.