### PR TITLE
Fix: adding import nececeary for using attention layers as bottlenecks

### DIFF
--- a/nbs/02_vision.external.timm.ipynb
+++ b/nbs/02_vision.external.timm.ipynb
@@ -155,6 +155,7 @@
    "source": [
     "#export\n",
     "from timm import create_model\n",
+    "from fastai.layers import _get_norm\n",
     "from fastai.vision.learner import _update_first_layer"
    ]
   },


### PR DESCRIPTION
Adding the following import 
from fastai.layers import _get_norm
in order for the following code to be able to run 

def BatchNormZero(nf, ndim=2, **kwargs):\n",
    "    \"BatchNorm layer with `nf` features and `ndim` initialized depending on `norm_type`. Weights initialized to zero.\"\n",
    "    return _get_norm('BatchNorm', nf, ndim, zero=True, **kwargs)\n",

After this fix it becomes possible to train a timm model based unet with attention or double_attention as bottleneck